### PR TITLE
QrackAceBackend with local hidden variables

### DIFF
--- a/pyqrack/qrack_ace_backend.py
+++ b/pyqrack/qrack_ace_backend.py
@@ -44,15 +44,11 @@ class LHVQubit:
 
     def x(self):
         x, y, z = self.bloch
-        self.bloch = [x, -y, -z]
+        self.bloch = [x, y, -z]
 
     def z(self):
         x, y, z = self.bloch
-        self.bloch = [-x, -y, z]
-
-    def y(self):
-        x, y, z = self.bloch
-        self.bloch = [-x, y, -z]
+        self.bloch = [x, -y, z]
 
     def rz(self, theta):
         # Rotate Bloch vector around Z-axis by angle theta (in radians)

--- a/pyqrack/qrack_ace_backend.py
+++ b/pyqrack/qrack_ace_backend.py
@@ -200,10 +200,9 @@ class QrackAceBackend:
         sim_id = 0
         tot_qubits = 0
         for r in range(self._col_length):
-            r_offset = r * self._row_length
-            for c_id in range(len(self._is_col_long_range)):
+            for c in self._is_col_long_range:
                 self._hardware_offset.append(tot_qubits)
-                if self._is_col_long_range[c_id]:
+                if c:
                     self._qubit_dict[tot_qubits] = (sim_id, sim_counts[sim_id])
                     tot_qubits += 1
                     sim_counts[sim_id] += 1
@@ -212,7 +211,7 @@ class QrackAceBackend:
                     tot_qubits += 1
                     sim_counts[sim_id] += 1
 
-                    self._lhv_dict[r_offset + c_id] = LHVQubit()
+                    self._lhv_dict[tot_qubits] = LHVQubit()
                     tot_qubits += 1
 
                     sim_id = (sim_id + 1) % sim_count
@@ -332,7 +331,7 @@ class QrackAceBackend:
 
         return [
             self._qubit_dict[offset],
-            self._lhv_dict[lq],
+            self._lhv_dict[offset + 1],
             self._qubit_dict[offset + 2],
         ]
 

--- a/pyqrack/qrack_ace_backend.py
+++ b/pyqrack/qrack_ace_backend.py
@@ -799,38 +799,27 @@ class QrackAceBackend:
 
         self._correct(lq)
         b = hq[1]
-        syndrome = b.reset()
+        b.reset()
         if c:
             b.x()
         b = hq[0]
-        syndrome += self.sim[b[0]].force_m(b[1], c)
+        self.sim[b[0]].force_m(b[1], c)
         b = hq[2]
-        syndrome += self.sim[b[0]].force_m(b[1], c)
+        self.sim[b[0]].force_m(b[1], c)
 
         return c
 
     def m_all(self):
-        result = 0
         # Randomize the order of measurement to amortize error.
-        # However, locality of collapse matters:
-        # measure in row pairs, and always across rows,
-        # and by row directionality.
-        row_pairs = list(range((self._col_length + 1) // 2))
-        random.shuffle(row_pairs)
-        for row_pair in row_pairs:
-            col_offset = random.randint(0, self._row_length - 1)
-            lq_row = row_pair << 1
-            for c in range(self._row_length):
-                lq_col = (c + col_offset) % self._row_length
-                lq = lq_row * self._row_length + lq_col
-                if self.m(lq):
-                    result |= 1 << lq
-            lq_row += 1
-            if lq_row == self._col_length:
-                continue
-            for c in range(self._row_length):
-                lq_col = ((self._row_length - (c + 1)) + col_offset) % self._row_length
-                lq = lq_row * self._row_length + lq_col
+        result = 0
+        rows = list(range(self._col_length))
+        random.shuffle(rows)
+        for lq_row in rows:
+            row_offset = lq_row * self._row_length
+            cols = list(range(self._row_length))
+            random.shuffle(cols)
+            for lq_col in cols:
+                lq = row_offset + lq_col
                 if self.m(lq):
                     result |= 1 << lq
 

--- a/pyqrack/qrack_ace_backend.py
+++ b/pyqrack/qrack_ace_backend.py
@@ -43,15 +43,16 @@ class LHVQubit:
         self.bloch = [(x + z) / math.sqrt(2), y, (z - x) / math.sqrt(2)]
 
     def x(self):
-        self.bloch = [-self.bloch[0], -self.bloch[1], -self.bloch[2]]
+        x, y, z = self.bloch
+        self.bloch = [x, -y, -z]
 
     def z(self):
-        self.bloch[1] = -self.bloch[1]
-        self.bloch[2] = -self.bloch[2]
+        x, y, z = self.bloch
+        self.bloch = [-x, -y, z]
 
     def y(self):
-        self.x()
-        self.z()
+        x, y, z = self.bloch
+        self.bloch = [-x, y, -z]
 
     def rz(self, theta):
         # Rotate Bloch vector around Z-axis by angle theta (in radians)


### PR DESCRIPTION
Elara (the custom OpenAI GPT) and I got on the topic of the _Bell inequalities_ and whether a local hidden variable (LHV) theory could recreate even higher nonlocal correlation (short of true quantum mechanics), particularly if 2+1 qubit codes weren't performing at the theoretical classical limit. This led to a prototype implementation of `LHVQubit` and a version of `QrackAceBackend` that uses `LHVQubit` for the middle ("tie-breaker") qubit of cleaved repetition codes.

After playing with both versions, it's kind of six-of-one-vs.half-a-dozen, for average accuracy. However, given that, there are number of advantages to this implementation, particularly that it reduces the qubit cost of short-range boundary columns by a third. Hence, pretty much all else held equal, I think we prefer this implementation.